### PR TITLE
feature/OpponentGrid

### DIFF
--- a/Slagschip/Assets/Scripts/Opponent Grid/OpponentGridHandler.cs
+++ b/Slagschip/Assets/Scripts/Opponent Grid/OpponentGridHandler.cs
@@ -14,13 +14,13 @@ namespace OpponentGrid
 
         private const byte _gridSize = GridHandler.gridSize;
 
-        private Button[] _gridButtons = new Button[_gridSize * _gridSize];
+        private Button[] _gridButtons = new Button[_gridSize * (_gridSize + 4)];
 
         private void Awake()
         {
             _document = GetComponent<UIDocument>();
         
-            for (byte i = 1; i <= _gridSize * _gridSize; i++)
+            for (byte i = 0; i < _gridSize * _gridSize; i++)
             {
                 Button _gridButton = new();
 
@@ -36,7 +36,7 @@ namespace OpponentGrid
                 _gridButtons[i] = _gridButton;
             }
 
-            for(byte i = 1; i <= _gridSize * 2; i++)
+            for(byte i = 0; i < _gridSize * 2; i++)
             {
                 Button _horizontalGridButton = new();
                 Button _verticalGridButton = new();
@@ -48,13 +48,13 @@ namespace OpponentGrid
                 _verticalGridButton.style.width = new StyleLength(new Length(100 / _gridSize, LengthUnit.Percent));
 
                 _horizontalGridButton.RegisterCallbackOnce<ClickEvent, byte>(SetTargetCell, (byte)(_gridSize * _gridSize + i));
-                _verticalGridButton.RegisterCallbackOnce<ClickEvent, byte>(SetTargetCell, (byte)(_gridSize * _gridSize + _gridSize * 2 + i));
+                _verticalGridButton.RegisterCallbackOnce<ClickEvent, byte>(SetTargetCell, (byte)(_gridSize * (_gridSize + 2) + i));
 
                 _document.rootVisualElement.Query("horizontal-grid-container").First().Add(_horizontalGridButton);
                 _document.rootVisualElement.Query("vertical-grid-container").First().Add(_verticalGridButton);
 
                 _gridButtons[_gridSize * _gridSize + i] = _horizontalGridButton;
-                _gridButtons[_gridSize * _gridSize + _gridSize * 2 + i] = _verticalGridButton;
+                _gridButtons[_gridSize * (_gridSize + 2) + i] = _verticalGridButton;
             }
         }
 
@@ -72,16 +72,20 @@ namespace OpponentGrid
         public void OnHitRpc(byte _targetCell)
         {
             if (IsClient)
+            {
                 GetCellButton(_targetCell).AddToClassList("hitted-grid-button");
                 GetCellButton(_targetCell).RemoveFromClassList("grid-button");
+            }
         }
 
         [Rpc(SendTo.NotMe)]
         public void OnMissRpc(byte _targetCell)
         {
             if (IsClient)
+            {
                 GetCellButton(_targetCell).AddToClassList("missed-grid-button");
                 GetCellButton(_targetCell).RemoveFromClassList("grid-button");
+            }
         }
     }
 }

--- a/Slagschip/Assets/Scripts/UI/StyleSheets/OpponentGrid.uss
+++ b/Slagschip/Assets/Scripts/UI/StyleSheets/OpponentGrid.uss
@@ -41,6 +41,7 @@
     padding: 0;
     border-width: 0;
     width: 50%;
+    background-color: rgba(255, 255, 255, 0);
 }
 
 .vertical-grid-button {
@@ -48,6 +49,7 @@
     padding: 0;
     border-width: 0;
     height: 50%;
+    background-color: rgba(255, 255, 255, 0);
 }
 
 .grid-button:hover {


### PR DESCRIPTION
Het indexen van de knoppen in `/Scripts/Opponent Grid/OpponentGridHandler.cs` is gefixed en de achtergronden van de torpedoknoppen in het raster zijn nu transparant.