### PR TITLE
feature/StartScreen

### DIFF
--- a/Slagschip/Assets/Scenes/Menu.unity
+++ b/Slagschip/Assets/Scenes/Menu.unity
@@ -715,7 +715,19 @@ MonoBehaviour:
       m_Calls: []
   JoinedSession:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1395624746}
+        m_TargetAssemblyTypeName: SceneManagement.SceneLoader, Assembly-CSharp
+        m_MethodName: LoadScene
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 102900000, guid: 59fb58b39e15a1a4baecf64a4dbcc8be, type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEditor.SceneAsset, UnityEditor.CoreModule
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   FailedToJoinSession:
     m_PersistentCalls:
       m_Calls:

--- a/Slagschip/Assets/Scripts/Scene Management/SceneLoader.cs
+++ b/Slagschip/Assets/Scripts/Scene Management/SceneLoader.cs
@@ -36,10 +36,10 @@ namespace SceneManagement
 
         private IEnumerator LoadNetworkedScene(string _sceneName)
         {
+            yield return new WaitForSeconds(loadDelay);
+
             if (NetworkManager.LocalClientId == 0 == IsOwner)
             {
-                yield return new WaitForSeconds(loadDelay);
-
                 LoadNetworkedSceneRpc(_sceneName);
             }
             else
@@ -96,6 +96,11 @@ namespace SceneManagement
             {
                 StartCoroutine(LoadLocalScene(_sceneName, _loadDelay));
             }
+        }
+
+        public void LoadScene(SceneAsset _scene)
+        {
+            StartCoroutine(LoadLocalScene(_scene.name));
         }
     }
 }

--- a/Slagschip/Assets/Scripts/UI/Handlers/MenuHandler.cs
+++ b/Slagschip/Assets/Scripts/UI/Handlers/MenuHandler.cs
@@ -68,8 +68,6 @@ namespace UIHandlers
 
         private void OnPlayCodeInputSubmitted(ClickEvent _event)
         {
-            sceneLoader.LoadScene(loadingScene.name, false);
-
             playCodeButton.onClick.Invoke();
         }
 


### PR DESCRIPTION
Het laadscherm start nu normaal wanneer je een sessie start of snel joint. Wanneer er een foute speelcode ingevoerd is, dan start hij niet het laadscherm op en komt er een errorbericht tevoorschijn.