### PR TITLE
feature/Cleanup

### DIFF
--- a/Slagschip/Assets/Scripts/UI/Handlers/DashboardHandler.cs
+++ b/Slagschip/Assets/Scripts/UI/Handlers/DashboardHandler.cs
@@ -34,8 +34,6 @@ namespace UIHandlers
 
         private void Awake()
         {
-            _readyPlayers.Value = new();
-
             _gameData.currentPlayerTurn.OnValueChanged += OnPlayerTurnChange;
 
             _document = GetComponent<UIDocument>();
@@ -119,6 +117,8 @@ namespace UIHandlers
         public override void OnNetworkSpawn()
         {
             base.OnNetworkSpawn();
+
+            _readyPlayers.Value = new();
 
             if (!IsHost)
                 _document.rootVisualElement.Query("grid-cover").First().style.visibility = Visibility.Visible;


### PR DESCRIPTION
Er werdt een warning doorgegeven wanneer de speler het spel in laad. Dit kwam omdat de network variable van de aantal spelers in de game werdt gebruikt voordat hij was aangemaakt. Hiervoor is alleen het script `Scripts/UI/Handlers/DashboardHandler.cs` aangepast.