### PR TITLE
feature/Dashboard

### DIFF
--- a/Slagschip/Assets/Scenes/Main.unity
+++ b/Slagschip/Assets/Scenes/Main.unity
@@ -1654,7 +1654,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Code
+  m_text: ------
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Slagschip/Assets/Scripts/UI/Handlers/DashboardHandler.cs
+++ b/Slagschip/Assets/Scripts/UI/Handlers/DashboardHandler.cs
@@ -8,6 +8,7 @@ using UnityEngine.Events;
 using UnityEngine.UIElements;
 using Unity.Services.Multiplayer;
 using TMPro;
+using System.Linq;
 
 namespace UIHandlers
 {
@@ -130,9 +131,9 @@ namespace UIHandlers
         {
             List<string> _joinedSessions = await MultiplayerService.Instance.GetJoinedSessionIdsAsync();
 
-            foreach(ISession _session in MultiplayerService.Instance.Sessions.Values)
+            foreach (ISession _session in MultiplayerService.Instance.Sessions.Values)
             {
-                if(_joinedSessions.Count == 1 && _session.Id == _joinedSessions[0])
+                if (_joinedSessions.Contains(_session.Id))
                     _sessionCodeText.text = _session.Code;
             }
 


### PR DESCRIPTION
De speelcode komt nu wel weer in beeld. In `/Scripts/UI/Handlers/DashboardHandler.cs` checkt ie nu alleen of de speler in de sessie zit, in plaats van ook te kijken of die alleen in één sessie zit.